### PR TITLE
Remove the line about Gateway Pass holders

### DIFF
--- a/docs/gateway-protocol/governance/governance.md
+++ b/docs/gateway-protocol/governance/governance.md
@@ -18,8 +18,6 @@ The purpose of governance is to perform the following tasks:
 
 ## Governance voting
 
-Voters are:
-* Governance token holders (including Gatekeepers)
-* Gateway Pass holders
+Voters are Governance token holders (including Gatekeepers).
 
 Voting power is determined by the amount of tokens the governor holds, the length of time the tokens have been held, and the constraints of the Gateway Pass.


### PR DESCRIPTION
"Gateway Pass holders" was supposed to be deleted from the governance voter, but was not.